### PR TITLE
Removed explicit parent library listings

### DIFF
--- a/FoodRemover/FoodRemover.csproj
+++ b/FoodRemover/FoodRemover.csproj
@@ -6,13 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AlphaFS" Version="2.2.6" />
-        <PackageReference Include="Mutagen.Bethesda" Version="0.22.1" />
         <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
-        <PackageReference Include="Mutagen.Bethesda.Skyrim" Version="0.22.1" />
-        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.12.1" />
+        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.13.1" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="Noggog.CSharpExt" Version="1.6.7" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hey Coyote!

Small tweak.  Was having trouble auto-upgrading to newer versions.

Reason for this is that you were explicitly listing parent libraries in your list of nugets.  The reason this causes problems is that as Synthesis auto-upgrades the Mutagen/Synthesis libraries... your project is locked into using that older version of say, CSharpExt.  The newer Mutagen wants newer CSharpExt, but can't get it, and so the build fails.

So it's probably better to just list the minimal libraries needed.  The parent libraries will get pulled in implicitly and be free-er to match as needed.

----------------------------

Also, while im here:
We started a new organization/group https://github.com/Synthesis-Collective
Can read about it here: https://github.com/Mutagen-Modding/Synthesis/wiki/Synthesis-Collective