### PR TITLE
Small API bump.  Removed newtonsoft from explicit listing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,0 @@
-<Project>
-    <PropertyGroup>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>nullable</WarningsAsErrors>
-    </PropertyGroup>
-</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+  </PropertyGroup>  
+</Project>

--- a/FoodRemover/FoodRemover.csproj
+++ b/FoodRemover/FoodRemover.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Platforms>AnyCPU;x64</Platforms>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
-        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.13.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="2.0.0" />
+    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.17.5" />
+  </ItemGroup>
 
 </Project>

--- a/FoodRemover/Program.cs
+++ b/FoodRemover/Program.cs
@@ -10,8 +10,7 @@ using Noggog;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using System.IO;
-
-
+using System.Threading.Tasks;
 
 namespace FoodRemover
 {
@@ -27,22 +26,15 @@ namespace FoodRemover
     {
         private static ModKey falskaarMod = ModKey.FromNameAndExtension("Falskaar.esm");
 
-        public static int Main(string[] args)
+        public static Task<int> Main(string[] args)
         {
-            return SynthesisPipeline.Instance.Patch<ISkyrimMod, ISkyrimModGetter>(
-                args: args,
-                patcher: RunPatch,
-                userPreferences: new UserPreferences()
-                {
-                    ActionsForEmptyArgs = new RunDefaultPatcher()
-                    {
-                        IdentifyingModKey = "FoodRemover.esp",
-                        TargetRelease = GameRelease.SkyrimSE
-                    }
-                });
+            return SynthesisPipeline.Instance
+                .SetTypicalOpen(GameRelease.SkyrimSE, "FoodRemover.esp")
+                .AddPatch<ISkyrimMod, ISkyrimModGetter>(RunPatch)
+                .Run(args);
         }
 
-        public static void RunPatch(SynthesisState<ISkyrimMod, ISkyrimModGetter> state)
+        public static void RunPatch(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)
         {
             //Start step 1. Initialize everything and read any user-config files
             var chanceShop = 25;


### PR DESCRIPTION
If/when mutagen updates newtonsoft on its end, the explicit listing in this project is then an older version of newtonsoft, which makes everything unhappy.

By omitting it, it will still be brought in but just magically be whatever version mutagen is using